### PR TITLE
Update setup docs with dependency instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ Docker.
    DATABASE_PATH=./data/home_dash_prod.db  # optional database location
    ```
 
+3. Fetch the application dependencies to generate a `mix.lock` file:
+
+   ```bash
+   docker compose run --rm app mix deps.get
+   ```
+
+   This step only needs to be performed once after cloning the repository.
+
 ## Running the app
 
 From the `home_dash` directory run:

--- a/home_dash/README.md
+++ b/home_dash/README.md
@@ -4,6 +4,12 @@ Minimal Phoenix LiveView dashboard.
 
 ## Development
 
+Install dependencies once after cloning:
+
+```bash
+docker compose run --rm app mix deps.get
+```
+
 ```
 docker compose up --build
 ```


### PR DESCRIPTION
## Summary
- mention fetching dependencies to create `mix.lock`

## Testing
- `mix --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685afa7eb5708331963ed47fdd673f5d