### PR TITLE
Add WAL and timeout config for SQLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Docker.
    DATABASE_PATH=./data/home_dash_prod.db  # optional database location
    ```
 
+The application uses SQLite. WAL mode and a long busy timeout are enabled to
+avoid `database is locked` errors when multiple connections attempt to access the
+database simultaneously.
+
 3. Fetch the application dependencies to generate a `mix.lock` file:
 
    ```bash

--- a/home_dash/config/dev.exs
+++ b/home_dash/config/dev.exs
@@ -3,7 +3,9 @@ import Config
 config :home_dash, HomeDash.Repo,
   database: Path.expand("../data/home_dash_dev.db", __DIR__),
   pool_size: 5,
-  show_sensitive_data_on_connection_error: true
+  show_sensitive_data_on_connection_error: true,
+  journal_mode: :wal,
+  busy_timeout: 60_000
 
 config :home_dash, HomeDashWeb.Endpoint,
   http: [ip: {0, 0, 0, 0}, port: 4000],

--- a/home_dash/config/runtime.exs
+++ b/home_dash/config/runtime.exs
@@ -3,7 +3,9 @@ import Config
 if config_env() == :prod do
   config :home_dash, HomeDash.Repo,
     database: System.get_env("DATABASE_PATH") || "./data/home_dash_prod.db",
-    pool_size: String.to_integer(System.get_env("POOL_SIZE") || "5")
+    pool_size: String.to_integer(System.get_env("POOL_SIZE") || "5"),
+    journal_mode: :wal,
+    busy_timeout: 60_000
 
   config :home_dash, HomeDashWeb.Endpoint,
     http: [:inet6, port: String.to_integer(System.get_env("PORT") || "4000")],

--- a/home_dash/config/test.exs
+++ b/home_dash/config/test.exs
@@ -3,7 +3,9 @@ import Config
 config :home_dash, HomeDash.Repo,
   database: Path.expand("../data/home_dash_test.db", __DIR__),
   pool: Ecto.Adapters.SQL.Sandbox,
-  pool_size: 5
+  pool_size: 5,
+  journal_mode: :wal,
+  busy_timeout: 60_000
 
 config :home_dash, HomeDashWeb.Endpoint,
   http: [ip: {127,0,0,1}, port: 4002],


### PR DESCRIPTION
## Summary
- tweak README with note about WAL/timeout
- set `journal_mode` to WAL and add a long `busy_timeout` in repo configs

## Testing
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b3630a39c83318b8540a0b9d0b8ad