### PR TITLE
Reorder asset build in Dockerfile

### DIFF
--- a/home_dash/Dockerfile
+++ b/home_dash/Dockerfile
@@ -8,8 +8,8 @@ RUN mix deps.get --only prod
 RUN mix deps.compile
 COPY assets assets
 RUN npm --prefix ./assets install
-RUN MIX_ENV=prod mix assets.deploy
 COPY . .
+RUN MIX_ENV=prod mix assets.deploy
 RUN mix compile
 RUN mix release
 


### PR DESCRIPTION
## Summary
- adjust `home_dash/Dockerfile` so `mix assets.deploy` runs after copying project files

## Testing
- `docker compose build --no-cache` *(fails: `docker: command not found`)*
- `docker compose up` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685b3d03917083318ad5db4963015628